### PR TITLE
D8CORE-2318: removing the link action. list items shouldn't have it

### DIFF
--- a/config/install/views.view.stanford_events.yml
+++ b/config/install/views.view.stanford_events.yml
@@ -818,7 +818,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<a class=\"su-link{% if su_event_source %} su-link--external{% else %} su-link--action{% endif %}\" href=\"{% if su_event_source %}{{ su_event_source }}{% else %}{{ view_node }}{% endif %}\">\r\n  {{ title }}\r\n</a>"
+            text: "<a class=\"su-link{% if su_event_source %} su-link--external{% else %}{% endif %}\" href=\"{% if su_event_source %}{{ su_event_source }}{% else %}{{ view_node }}{% endif %}\">\r\n  {{ title }}\r\n</a>"
             make_link: false
             path: ''
             absolute: false
@@ -1824,7 +1824,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<a class=\"su-link{% if su_event_source %} su-link--external{% else %} su-link--action{% endif %}\" href=\"{% if su_event_source %}{{ su_event_source }}{% else %}{{ view_node }}{% endif %}\">\r\n  {{ title }}\r\n</a>"
+            text: "<a class=\"su-link{% if su_event_source %} su-link--external{% else %} {% endif %}\" href=\"{% if su_event_source %}{{ su_event_source }}{% else %}{{ view_node }}{% endif %}\">\r\n  {{ title }}\r\n</a>"
             make_link: false
             path: '{{ su_event_source }}'
             absolute: false

--- a/config/install/views.view.stanford_events.yml
+++ b/config/install/views.view.stanford_events.yml
@@ -818,7 +818,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<a class=\"su-link{% if su_event_source %} su-link--external{% else %}{% endif %}\" href=\"{% if su_event_source %}{{ su_event_source }}{% else %}{{ view_node }}{% endif %}\">\r\n  {{ title }}\r\n</a>"
+            text: "<a class=\"su-link{% if su_event_source %} su-link--external{% endif %}\" href=\"{% if su_event_source %}{{ su_event_source }}{% else %}{{ view_node }}{% endif %}\">\r\n  {{ title }}\r\n</a>"
             make_link: false
             path: ''
             absolute: false

--- a/templates/components/event-schedule/event-schedule.html.twig
+++ b/templates/components/event-schedule/event-schedule.html.twig
@@ -22,8 +22,6 @@
   {%- set is_external = su_event_url|render|striptags|split('//')[1] ? true : false -%}
   {%- if is_external -%}
     {%- set link_attributes = link_attributes.addClass('su-link--external') -%}
-  {%- else -%}
-    {%- set link_attributes = link_attributes.addClass('su-link--action') -%}
   {%- endif %}
 {%- endif -%}
 

--- a/templates/components/events-list/events-list.html.twig
+++ b/templates/components/events-list/events-list.html.twig
@@ -34,8 +34,6 @@
   {%- set is_external = su_event_url|render|striptags|split('//')[1] ? true : false -%}
   {%- if is_external -%}
     {%- set link_attributes = link_attributes.addClass('su-link--external') -%}
-  {%- else -%}
-    {%- set link_attributes = link_attributes.addClass('su-link--action') -%}
   {%- endif %}
 {%- endif -%}
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removing the su-link--action on the Event list pages. If the link goes to a node, there doesn't need to be the right arrow.

# Review By (Date)
- Soonish

# Criticality
- Med

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to Events.
3. Verify Event List pages (filtered and not) with a Node page doesn't have the > on the link. It should also not appear on the Event-Series page as well. 

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Core Product

# Associated Issues and/or People
- D8CORE-2318
- https://github.com/SU-SWS/stanford_profile/pull/245

