### PR TITLE
D8CORE-2337 D8CORE-2370: changing col with to 8 from 9

### DIFF
--- a/templates/sections/event-body-two-column.html.twig
+++ b/templates/sections/event-body-two-column.html.twig
@@ -4,7 +4,7 @@
  */
  #}
 <div{{ attributes.addClass('centered-container', 'su-events-details', 'flex-container', settings.extra_classes) }}>
-  <div class="flex-9-of-12 flex-container centered-container details-wrapper">
+  <div class="flex-8-of-12 flex-container centered-container details-wrapper">
     <div class="flex-container centered-container details">
     {% if content.main|render %}
       <div {{ region_attributes.main.addClass('body-region', 'flex-6-of-12') }}>
@@ -19,7 +19,7 @@
     {% endif %}
    </div>
   {% if content.cta|render %}
-   <div class="flex-9-of-12 centered-container cta">
+   <div class="flex-8-of-12 centered-container cta">
       <div{{ region_attributes.cta.addClass('cta') }}>
         {{ content.cta }}
       </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change the col width on Events to 8 from 9.

# Review By (Date)
- Wednesday

# Criticality
- low
- Effects Events for SOE and Basic

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to an event page and then an Event Series. 
3. Verify all the Event details, body content, and schedule paragraph should all occupy one "content well": 8:12 columns, centered.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- 

# Associated Issues and/or People
- D8CORE-2337 
- D8CORE-2380
- @ishahism 

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
