### PR TITLE
D8CORE-2306: removed sorting controls in the event schedule entity reference field.

### DIFF
--- a/stanford_events.module
+++ b/stanford_events.module
@@ -218,6 +218,22 @@ function stanford_events_cron() {
  * to use that.
  */
 function stanford_events_preprocess_field_multiple_value_form(&$variables) {
+  if ($variables["element"]["#field_name"] == 'su_event_schedule') {
+    unset($variables['table']['#header']);
+    unset($variables['table']['#tabledrag']);
+    foreach ($variables['table']['#rows'] as &$row) {
+      foreach (array_keys($row['data']) as $key) {
+        if (!empty($row['data'][$key]['class'])
+          && array_intersect($row['data'][$key]['class'], [
+            'field-multiple-drag',
+            'delta-order',
+          ])) {
+          unset($row['data'][$key]);
+        }
+      }
+    }
+  }
+
   foreach (Element::children($variables['element']) as $child) {
     $child_element = &$variables['element'][$child];
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- UX update for events admin.
- Removes the row weight and drag 'n drop sorting for event schedules.

# Review By (Date)
- 11/5/2020

# Criticality
- 2 of 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. create an event that has a schedule.
3. Add some things to the schedule.  Notice there's no row weights or drag-n-drop reordering.
4. Save the event. Notice the schedule is sorted based on times.

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/D8CORE-2306

